### PR TITLE
Add CI workflows for package build and testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: Build Package
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build tooling
+        run: pip install build
+      - name: Build package
+        run: python -m build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/ha_expiring_consumables/__init__.py
+++ b/ha_expiring_consumables/__init__.py
@@ -1,0 +1,3 @@
+"""HA Expiring Consumables package."""
+
+__all__ = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ha-expiring-consumables"
+version = "0.1.0"
+description = "Home Assistant plugin to track consumables"
+readme = "README.md"
+authors = [{name = "Unknown"}]
+requires-python = ">=3.9"
+
+[project.urls]
+Home = "https://github.com/user/HA-Expiring-Consumables"


### PR DESCRIPTION
## Summary
- add workflow to build distribution packages
- add workflow to run tests on pushes and PRs
- introduce minimal package metadata for building

## Testing
- `pytest`
- `python -m pip install build` *(fails: Could not find a version that satisfies the requirement build)*
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_68adbb47133c832e94b56cbf5ce7b4a5