### PR TITLE
Add Home Assistant manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.1 - 2025-08-26
+- Add Home Assistant manifest.
+- Set code owner to @dfiore1230.
+
+## 0.1.0 - 2025-08-26
+- Initial release.

--- a/ha_expiring_consumables/__init__.py
+++ b/ha_expiring_consumables/__init__.py
@@ -1,3 +1,5 @@
 """HA Expiring Consumables package."""
 
-__all__ = []
+__version__ = "0.1.1"
+
+__all__ = ["__version__"]

--- a/ha_expiring_consumables/manifest.json
+++ b/ha_expiring_consumables/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "ha_expiring_consumables",
+  "name": "HA Expiring Consumables",
+  "version": "0.1.1",
+  "documentation": "https://github.com/user/HA-Expiring-Consumables",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": ["@dfiore1230"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-expiring-consumables"
-version = "0.1.0"
+version = "0.1.1"
 description = "Home Assistant plugin to track consumables"
 readme = "README.md"
 authors = [{name = "Unknown"}]
@@ -12,3 +12,6 @@ requires-python = ">=3.9"
 
 [project.urls]
 Home = "https://github.com/user/HA-Expiring-Consumables"
+
+[tool.setuptools.package-data]
+ha_expiring_consumables = ["manifest.json"]


### PR DESCRIPTION
## Summary
- add Home Assistant `manifest.json`
- expose manifest in packaging and bump version to 0.1.1
- set code owner to @dfiore1230

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adbed674d4832eba6363512d754014