### PR TITLE
Add basic config flow for HA Expiring Consumables

### DIFF
--- a/custom_components/ha_expiring_consumables/__init__.py
+++ b/custom_components/ha_expiring_consumables/__init__.py
@@ -1,5 +1,21 @@
-"""HA Expiring Consumables package."""
+"""HA Expiring Consumables integration."""
+
+from .const import DOMAIN
 
 __version__ = "0.1.3"
+
+
+async def async_setup_entry(hass, entry):
+    """Set up HA Expiring Consumables from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = {}
+    return True
+
+
+async def async_unload_entry(hass, entry):
+    """Unload a config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id, None)
+    return True
+
 
 __all__ = ["__version__"]

--- a/custom_components/ha_expiring_consumables/config_flow.py
+++ b/custom_components/ha_expiring_consumables/config_flow.py
@@ -1,0 +1,24 @@
+"""Config flow for the HA Expiring Consumables integration."""
+
+from __future__ import annotations
+
+import voluptuous as vol
+from homeassistant import config_entries
+
+from .const import DOMAIN, NAME
+
+
+class HAExpiringConsumablesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for HA Expiring Consumables."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step initiated by the user."""
+        if self._async_current_entries():
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
+
+        return self.async_create_entry(title=NAME, data={})

--- a/custom_components/ha_expiring_consumables/const.py
+++ b/custom_components/ha_expiring_consumables/const.py
@@ -1,0 +1,4 @@
+"""Constants for the HA Expiring Consumables integration."""
+
+DOMAIN = "ha_expiring_consumables"
+NAME = "HA Expiring Consumables"

--- a/custom_components/ha_expiring_consumables/manifest.json
+++ b/custom_components/ha_expiring_consumables/manifest.json
@@ -5,5 +5,6 @@
   "documentation": "https://github.com/user/HA-Expiring-Consumables",
   "requirements": [],
   "dependencies": [],
-  "codeowners": ["@dfiore1230"]
+  "codeowners": ["@dfiore1230"],
+  "config_flow": true
 }


### PR DESCRIPTION
## Summary
- enable UI-based setup for HA Expiring Consumables via config flow
- add constants module and config entry helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add65f0f20832eb4edf1bea58d5fd2