### PR TITLE
Allow multiple HA Expiring Consumables entries

### DIFF
--- a/custom_components/ha_expiring_consumables/config_flow.py
+++ b/custom_components/ha_expiring_consumables/config_flow.py
@@ -15,9 +15,6 @@ class HAExpiringConsumablesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step initiated by the user."""
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
-
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
 


### PR DESCRIPTION
## Summary
- allow configuring multiple expiring consumable entities by removing single-instance restriction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add8ce882c832e86f29ed275fb46f3