### PR TITLE
ci: create release on tag build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
     tags: ['*']
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -19,3 +22,8 @@ jobs:
         run: pip install build
       - name: Build package
         run: python -m build
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*


### PR DESCRIPTION
## Summary
- create GitHub release when build workflow runs on tags

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68add99e3e28832e982c8de593d6d198