### PR TITLE
Fix blank configuration options

### DIFF
--- a/custom_components/ha_expiring_consumables/config_flow.py
+++ b/custom_components/ha_expiring_consumables/config_flow.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import voluptuous as vol
 from homeassistant import config_entries
 
 from .const import DOMAIN, NAME
@@ -15,7 +14,4 @@ class HAExpiringConsumablesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step initiated by the user."""
-        if user_input is None:
-            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
-
         return self.async_create_entry(title=NAME, data={})

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,30 @@
+import asyncio
+import importlib
+import sys
+import types
+from pathlib import Path
+
+def test_config_flow_creates_entry(monkeypatch):
+    """Ensure the config flow creates an entry without showing a form."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+
+    ha_module = types.ModuleType("homeassistant")
+    config_entries = types.ModuleType("homeassistant.config_entries")
+
+    class DummyConfigFlow:
+        def __init_subclass__(cls, **kwargs):
+            pass
+
+        def async_create_entry(self, title, data):
+            return {"type": "create_entry", "title": title, "data": data}
+
+    config_entries.ConfigFlow = DummyConfigFlow
+    ha_module.config_entries = config_entries
+    monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
+    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries)
+
+    cf_module = importlib.import_module("ha_expiring_consumables.config_flow")
+    flow = cf_module.HAExpiringConsumablesConfigFlow()
+    result = asyncio.run(flow.async_step_user())
+    assert result["type"] == "create_entry"
+    assert result["title"] == cf_module.NAME


### PR DESCRIPTION
## Summary
- Auto-complete the configuration flow so no empty form is shown
- Add unit test for the config flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68addb485690832e89382ee09f23df6d