### PR TITLE
Add form options to config flow

### DIFF
--- a/custom_components/ha_expiring_consumables/config_flow.py
+++ b/custom_components/ha_expiring_consumables/config_flow.py
@@ -14,4 +14,13 @@ class HAExpiringConsumablesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step initiated by the user."""
-        return self.async_create_entry(title=NAME, data={})
+        if user_input is None:
+            data_schema = {
+                "type": str,
+                "duration": int,
+                "start_date": str,
+            }
+            return self.async_show_form(step_id="user", data_schema=data_schema)
+
+        title = user_input.get("type", NAME)
+        return self.async_create_entry(title=title, data=user_input)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,8 +4,8 @@ import sys
 import types
 from pathlib import Path
 
-def test_config_flow_creates_entry(monkeypatch):
-    """Ensure the config flow creates an entry without showing a form."""
+def test_config_flow_form_and_entry(monkeypatch):
+    """Ensure the config flow shows a form and creates an entry."""
     sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
 
     ha_module = types.ModuleType("homeassistant")
@@ -18,6 +18,9 @@ def test_config_flow_creates_entry(monkeypatch):
         def async_create_entry(self, title, data):
             return {"type": "create_entry", "title": title, "data": data}
 
+        def async_show_form(self, step_id, data_schema):
+            return {"type": "form", "step_id": step_id, "data_schema": data_schema}
+
     config_entries.ConfigFlow = DummyConfigFlow
     ha_module.config_entries = config_entries
     monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
@@ -25,6 +28,14 @@ def test_config_flow_creates_entry(monkeypatch):
 
     cf_module = importlib.import_module("ha_expiring_consumables.config_flow")
     flow = cf_module.HAExpiringConsumablesConfigFlow()
+
+    # Initial call should show the form
     result = asyncio.run(flow.async_step_user())
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+    user_input = {"type": "filter", "duration": 30, "start_date": "2024-01-01"}
+    result = asyncio.run(flow.async_step_user(user_input=user_input))
     assert result["type"] == "create_entry"
-    assert result["title"] == cf_module.NAME
+    assert result["title"] == user_input["type"]
+    assert result["data"] == user_input


### PR DESCRIPTION
## Summary
- Prompt for type, duration, and start date when adding integration
- Test config flow shows form and stores provided data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68addd1e99bc832eae924c8d30947dce