### PR TITLE
Revert to basic config flow

### DIFF
--- a/custom_components/ha_expiring_consumables/config_flow.py
+++ b/custom_components/ha_expiring_consumables/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import voluptuous as vol
 from homeassistant import config_entries
 
 from .const import DOMAIN, NAME
@@ -15,12 +16,6 @@ class HAExpiringConsumablesConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step initiated by the user."""
         if user_input is None:
-            data_schema = {
-                "type": str,
-                "duration": int,
-                "start_date": str,
-            }
-            return self.async_show_form(step_id="user", data_schema=data_schema)
+            return self.async_show_form(step_id="user", data_schema=vol.Schema({}))
 
-        title = user_input.get("type", NAME)
-        return self.async_create_entry(title=title, data=user_input)
+        return self.async_create_entry(title=NAME, data={})


### PR DESCRIPTION
## Summary
- Restore original config flow using a blank voluptuous schema
- Update tests to match new flow and stub missing dependencies

## Testing
- `pip install voluptuous`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68addee6f5a8832eb9fff9cece8b13d0