### PR TITLE
feat: allow reconfiguring consumables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 0.1.10 - 2025-08-26
 - Link sensor and button to a renamable device
 
+## Unreleased
+- Allow reconfiguring consumables from the UI including name, type, duration and expiry date override
+
 ## 0.1.8 - 2025-08-26
 - 10th Tries a charm?
 

--- a/custom_components/consumable_expiration/config_flow.py
+++ b/custom_components/consumable_expiration/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_ITEM_TYPE,
     CONF_DURATION_DAYS,
     CONF_START_DATE,
+    CONF_EXPIRY_DATE_OVERRIDE,
     CONF_ICON,
     DEFAULT_ICON_MAP,
 )
@@ -36,7 +37,11 @@ class ConsumableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             item_type = user_input.get(CONF_ITEM_TYPE)
             icon = user_input.get(CONF_ICON)
             duration = int(user_input[CONF_DURATION_DAYS])
-            start_date = user_input[CONF_START_DATE]
+            start_date = user_input.get(CONF_START_DATE)
+            expiry_override = user_input.get(CONF_EXPIRY_DATE_OVERRIDE)
+
+            if expiry_override:
+                start_date = expiry_override - dt.timedelta(days=duration)
 
             if duration < 1:
                 errors["base"] = "invalid_duration"
@@ -55,7 +60,9 @@ class ConsumableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 }
                 options = {
                     CONF_DURATION_DAYS: duration,
-                    CONF_START_DATE: start_date.isoformat() if hasattr(start_date, "isoformat") else str(start_date),
+                    CONF_START_DATE: start_date.isoformat()
+                    if hasattr(start_date, "isoformat")
+                    else str(start_date),
                 }
                 return self.async_create_entry(title=name, data=data, options=options)
 
@@ -73,7 +80,8 @@ class ConsumableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(CONF_DURATION_DAYS, default=90): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=1, max=1825, step=1, mode=selector.NumberSelectorMode.BOX)
             ),
-            vol.Required(CONF_START_DATE, default=today): selector.DateSelector()
+            vol.Required(CONF_START_DATE, default=today): selector.DateSelector(),
+            vol.Optional(CONF_EXPIRY_DATE_OVERRIDE): selector.DateSelector(),
         })
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
@@ -84,12 +92,36 @@ class ConsumableOptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry = config_entry
 
     async def async_step_init(self, user_input: dict | None = None) -> FlowResult:
-        if user_input is not None:
-            # Save options
-            return self.async_create_entry(title="", data=user_input)
-
         data = self.config_entry.data
         options = self.config_entry.options
+
+        if user_input is not None:
+            name = user_input[CONF_NAME].strip()
+            item_type = user_input.get(CONF_ITEM_TYPE)
+            icon = user_input.get(CONF_ICON)
+            duration = int(user_input[CONF_DURATION_DAYS])
+            start_date = user_input.get(CONF_START_DATE)
+            expiry_override = user_input.get(CONF_EXPIRY_DATE_OVERRIDE)
+
+            if expiry_override:
+                start_date = expiry_override - dt.timedelta(days=duration)
+
+            new_data = data.copy()
+            new_data.update({
+                CONF_NAME: name,
+                CONF_ITEM_TYPE: item_type,
+                CONF_ICON: icon,
+            })
+            self.hass.config_entries.async_update_entry(self.config_entry, data=new_data)
+
+            new_options = {
+                CONF_DURATION_DAYS: duration,
+                CONF_START_DATE: start_date.isoformat()
+                if hasattr(start_date, "isoformat")
+                else str(start_date),
+            }
+            return self.async_create_entry(title="", data=new_options)
+
         # Parse existing date
         try:
             current_date = options.get(CONF_START_DATE)
@@ -99,12 +131,23 @@ class ConsumableOptionsFlowHandler(config_entries.OptionsFlow):
         except Exception:
             current_date = dt.date.today()
 
+        duration = int(options.get(CONF_DURATION_DAYS, 90))
+        due_date = current_date + dt.timedelta(days=duration)
+
         schema = vol.Schema({
-            vol.Required(CONF_DURATION_DAYS, default=options.get(CONF_DURATION_DAYS, 90)): selector.NumberSelector(
+            vol.Required(CONF_NAME, default=data.get(CONF_NAME)): selector.TextSelector(),
+            vol.Optional(CONF_ITEM_TYPE, default=data.get(CONF_ITEM_TYPE)): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(DEFAULT_ICON_MAP.keys()),
+                    mode=selector.SelectSelectorMode.DROPDOWN
+                )
+            ),
+            vol.Optional(CONF_ICON, default=data.get(CONF_ICON)): selector.IconSelector(),
+            vol.Required(CONF_DURATION_DAYS, default=duration): selector.NumberSelector(
                 selector.NumberSelectorConfig(min=1, max=1825, step=1, mode=selector.NumberSelectorMode.BOX)
             ),
             vol.Required(CONF_START_DATE, default=current_date): selector.DateSelector(),
-            vol.Optional(CONF_ICON, default=data.get(CONF_ICON)): selector.IconSelector(),
+            vol.Optional(CONF_EXPIRY_DATE_OVERRIDE, default=due_date): selector.DateSelector(),
         })
         return self.async_show_form(step_id="init", data_schema=schema)
 

--- a/custom_components/consumable_expiration/const.py
+++ b/custom_components/consumable_expiration/const.py
@@ -7,6 +7,7 @@ CONF_NAME = "name"
 CONF_ITEM_TYPE = "item_type"
 CONF_DURATION_DAYS = "duration_days"
 CONF_START_DATE = "start_date"
+CONF_EXPIRY_DATE_OVERRIDE = "expiry_date_override"
 CONF_ICON = "icon"
 
 # Default icon mapping for common items (Material Design Icons names)

--- a/custom_components/consumable_expiration/strings.json
+++ b/custom_components/consumable_expiration/strings.json
@@ -5,7 +5,15 @@
     "step": {
       "user": {
         "title": "Add a consumable",
-        "description": "Create a sensor that counts days remaining until replacement is due."
+        "description": "Create a sensor that counts days remaining until replacement is due.",
+        "data": {
+          "name": "Name",
+          "item_type": "Item type",
+          "icon": "Icon",
+          "duration_days": "Duration (days)",
+          "start_date": "Start date",
+          "expiry_date_override": "Expiry date override"
+        }
       }
     },
     "error": {
@@ -17,7 +25,15 @@
     "step": {
       "init": {
         "title": "Edit consumable",
-        "description": "Update duration, start date, or icon."
+        "description": "Update name, type, duration, start date, icon, or override expiry date.",
+        "data": {
+          "name": "Name",
+          "item_type": "Item type",
+          "icon": "Icon",
+          "duration_days": "Duration (days)",
+          "start_date": "Start date",
+          "expiry_date_override": "Expiry date override"
+        }
       }
     }
   },

--- a/custom_components/consumable_expiration/translations/en.json
+++ b/custom_components/consumable_expiration/translations/en.json
@@ -5,7 +5,15 @@
     "step": {
       "user": {
         "title": "Add a consumable",
-        "description": "Create a sensor that counts days remaining until replacement is due."
+        "description": "Create a sensor that counts days remaining until replacement is due.",
+        "data": {
+          "name": "Name",
+          "item_type": "Item type",
+          "icon": "Icon",
+          "duration_days": "Duration (days)",
+          "start_date": "Start date",
+          "expiry_date_override": "Expiry date override"
+        }
       }
     },
     "error": {
@@ -17,7 +25,15 @@
     "step": {
       "init": {
         "title": "Edit consumable",
-        "description": "Update duration, start date, or icon."
+        "description": "Update name, type, duration, start date, icon, or override expiry date.",
+        "data": {
+          "name": "Name",
+          "item_type": "Item type",
+          "icon": "Icon",
+          "duration_days": "Duration (days)",
+          "start_date": "Start date",
+          "expiry_date_override": "Expiry date override"
+        }
       }
     }
   },

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -167,3 +167,14 @@ def test_config_flow_form_and_entry(monkeypatch):
     assert result["data"][cf_module.CONF_NAME] == "Filter"
     assert result["options"][cf_module.CONF_DURATION_DAYS] == 30
     assert result["options"][cf_module.CONF_START_DATE] == "2024-01-01"
+
+    # Test expiry date override calculates start date correctly
+    flow2 = cf_module.ConsumableConfigFlow()
+    user_input2 = {
+        cf_module.CONF_NAME: "Filter",
+        cf_module.CONF_DURATION_DAYS: 30,
+        cf_module.CONF_START_DATE: dt.date(2024, 1, 1),
+        cf_module.CONF_EXPIRY_DATE_OVERRIDE: dt.date(2024, 2, 1),
+    }
+    result2 = asyncio.run(flow2.async_step_user(user_input=user_input2))
+    assert result2["options"][cf_module.CONF_START_DATE] == "2024-01-02"


### PR DESCRIPTION
## Summary
- allow renaming consumable entries and changing type, duration, start date or icon from the UI
- support manual expiry-date override when configuring
- document new options and cover expiry override logic with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adf5eab5b8832e88ae9256c0fbce3e