### PR TITLE
Fix indentation in config flow test

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -210,8 +210,3 @@ def test_config_flow_form_and_entry(monkeypatch):
     }
     result3 = asyncio.run(options_flow.async_step_init(user_input=user_input3))
     assert result3["data"][cf_module.CONF_START_DATE] == "2024-01-02"
-        cf_module.CONF_START_DATE: dt.date(2024, 1, 1),
-        cf_module.CONF_EXPIRY_DATE_OVERRIDE: dt.date(2024, 2, 1),
-    }
-    result2 = asyncio.run(flow2.async_step_user(user_input=user_input2))
-    assert result2["options"][cf_module.CONF_START_DATE] == "2024-01-02"


### PR DESCRIPTION
## Summary
- remove leftover lines from `test_config_flow.py` that triggered an indentation error

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68adfb2e8bec832e9247440793a4556f