### PR TITLE
Fix options flow retrieval for updates

### DIFF
--- a/custom_components/consumable_expiration/config_flow.py
+++ b/custom_components/consumable_expiration/config_flow.py
@@ -90,6 +90,12 @@ class ConsumableConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        """Get the options flow for this handler."""
+        return ConsumableOptionsFlowHandler(config_entry)
+
 
 class ConsumableOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
@@ -159,8 +165,3 @@ class ConsumableOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(CONF_EXPIRY_DATE_OVERRIDE, default=due_date): selector.DateSelector(),
         })
         return self.async_show_form(step_id="init", data_schema=schema)
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
-        return ConsumableOptionsFlowHandler(config_entry)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -192,7 +192,7 @@ def test_config_flow_form_and_entry(monkeypatch):
         cf_module.CONF_START_DATE: "2024-01-01",
     }
 
-    options_flow = cf_module.ConsumableOptionsFlowHandler(config_entry)
+    options_flow = cf_module.ConsumableConfigFlow.async_get_options_flow(config_entry)
 
     class DummyConfigEntries:
         def async_update_entry(self, entry, data=None):


### PR DESCRIPTION
## Summary
- Expose `async_get_options_flow` on `ConsumableConfigFlow` so options can be updated after device creation
- Adjust tests to retrieve options flow through the config flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae01e1eb38832eac7ffff96194969f