### PR TITLE
Add service validation and fix entity mapping

### DIFF
--- a/custom_components/consumable_expiration/config_flow.py
+++ b/custom_components/consumable_expiration/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 

--- a/custom_components/consumable_expiration/sensor.py
+++ b/custom_components/consumable_expiration/sensor.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import datetime as dt
-from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor.const import SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
@@ -17,7 +16,6 @@ from homeassistant.util import dt as dt_util
 from .const import (
     DOMAIN,
     CONF_NAME,
-    CONF_ITEM_TYPE,
     CONF_DURATION_DAYS,
     CONF_START_DATE,
     CONF_ICON,
@@ -42,9 +40,8 @@ class ConsumableExpirationSensor(SensorEntity):
         self.entry = entry
         self._attr_unique_id = f"{entry.entry_id}_days_remaining"
         # Map entity id to entry for services
-        hass.data[DOMAIN]["entity_map"][
-            self.entity_id if hasattr(self, "entity_id") else self._attr_unique_id
-        ] = entry.entry_id
+        key = self.entity_id if self.entity_id else self._attr_unique_id
+        hass.data[DOMAIN]["entity_map"][key] = entry.entry_id
         self._unsub_midnight = None
 
     async def async_added_to_hass(self) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -36,6 +36,11 @@ def test_config_flow_form_and_entry(monkeypatch):
     selector = types.ModuleType("homeassistant.helpers.selector")
     const_module = types.ModuleType("homeassistant.const")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    config_validation = types.ModuleType("homeassistant.helpers.config_validation")
+    def _cv_identity(value):
+        return value
+    config_validation.entity_id = _cv_identity
+    config_validation.date = _cv_identity
 
     class ConfigEntry:
         pass
@@ -139,6 +144,7 @@ def test_config_flow_form_and_entry(monkeypatch):
     entity_registry.async_get = async_get
     helpers.selector = selector
     helpers.entity_registry = entity_registry
+    helpers.config_validation = config_validation
     ha_module.helpers = helpers
 
     monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
@@ -148,6 +154,7 @@ def test_config_flow_form_and_entry(monkeypatch):
     monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.selector", selector)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity_registry", entity_registry)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.config_validation", config_validation)
     monkeypatch.setitem(sys.modules, "homeassistant.const", const_module)
 
     cf_module = importlib.import_module("consumable_expiration.config_flow")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -39,10 +39,16 @@ def test_import_version(monkeypatch):
 
     helpers = types.ModuleType("homeassistant.helpers")
     entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    config_validation = types.ModuleType("homeassistant.helpers.config_validation")
     def async_get(hass):
         return object()
     entity_registry.async_get = async_get
+    def _cv_identity(value):
+        return value
+    config_validation.entity_id = _cv_identity
+    config_validation.date = _cv_identity
     helpers.entity_registry = entity_registry
+    helpers.config_validation = config_validation
 
     monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
     monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries)
@@ -50,6 +56,7 @@ def test_import_version(monkeypatch):
     monkeypatch.setitem(sys.modules, "homeassistant.core", core)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity_registry", entity_registry)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.config_validation", config_validation)
 
     pkg = importlib.import_module("consumable_expiration")
     assert pkg is not None


### PR DESCRIPTION
## Summary
- avoid mapping `None` entity ids during sensor initialization
- validate service calls with voluptuous schemas
- simplify async_setup_entry logic and remove unused imports

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae06e1e320832e82aec9335042c96f