### PR TITLE
Allow partial capability edits

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -218,6 +218,24 @@ def test_config_flow_form_and_entry(monkeypatch):
     result3 = asyncio.run(options_flow.async_step_init(user_input=user_input3))
     assert result3["data"][cf_module.CONF_START_DATE] == "2024-01-02"
 
+    # Partial update should not require all fields
+    config_entry_partial = cf_module.config_entries.ConfigEntry()
+    config_entry_partial.data = {
+        cf_module.CONF_NAME: "Filter",
+        cf_module.CONF_ITEM_TYPE: None,
+        cf_module.CONF_ICON: None,
+    }
+    config_entry_partial.options = {
+        cf_module.CONF_DURATION_DAYS: 30,
+        cf_module.CONF_START_DATE: "2024-01-01",
+    }
+    options_flow_partial = cf_module.ConsumableConfigFlow.async_get_options_flow(config_entry_partial)
+    options_flow_partial.hass = hass
+    user_partial = {cf_module.CONF_NAME: "Updated"}
+    result_partial = asyncio.run(options_flow_partial.async_step_init(user_input=user_partial))
+    assert result_partial["data"][cf_module.CONF_START_DATE] == "2024-01-01"
+    assert config_entry_partial.data[cf_module.CONF_NAME] == "Updated"
+
     # Test reconfigure flow delegates to options flow
     config_entry2 = cf_module.config_entries.ConfigEntry()
     config_entry2.entry_id = "abc123"


### PR DESCRIPTION
## Summary
- Allow editing only provided fields when reconfiguring consumables
- Make options flow fields optional and add test coverage for partial updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04f25a77c832e9bd4de44a3c7ce8d