### PR TITLE
Avoid unknown default state for Mark Replaced button

### DIFF
--- a/custom_components/consumable_expiration/__init__.py
+++ b/custom_components/consumable_expiration/__init__.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 import datetime as dt
 import logging
 
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -73,6 +70,9 @@ async def _update_listener(hass: HomeAssistant, entry: ConfigEntry):
 def _register_services(hass: HomeAssistant) -> None:
     if getattr(hass.data[DOMAIN], "services_registered", False):
         return
+
+    import voluptuous as vol
+    import homeassistant.helpers.config_validation as cv
 
     async def _resolve_entry_from_entity(hass: HomeAssistant, entity_id: str):
         emap: dict[str, str] = hass.data[DOMAIN]["entity_map"]

--- a/custom_components/consumable_expiration/button.py
+++ b/custom_components/consumable_expiration/button.py
@@ -19,6 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 class MarkReplacedButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "mark_replaced"
+    _attr_state = "idle"
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.hass = hass
@@ -43,3 +44,5 @@ class MarkReplacedButton(ButtonEntity):
         today = dt.date.today().isoformat()
         options = {**self.entry.options, CONF_START_DATE: today}
         self.hass.config_entries.async_update_entry(self.entry, options=options)
+        self._attr_state = dt.datetime.now().isoformat()
+        self.async_write_ha_state()

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,64 @@
+
+import sys
+import types
+from pathlib import Path
+
+def test_button_default_state(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+
+    ha_module = types.ModuleType("homeassistant")
+    components = types.ModuleType("homeassistant.components")
+    button_module = types.ModuleType("homeassistant.components.button")
+
+    class ButtonEntity:
+        def __init__(self):
+            self._attr_state = None
+        def async_write_ha_state(self):
+            pass
+    button_module.ButtonEntity = ButtonEntity
+    components.button = button_module
+    ha_module.components = components
+
+    config_entries = types.ModuleType("homeassistant.config_entries")
+    class ConfigEntry:
+        def __init__(self):
+            self.entry_id = "1"
+            self.data = {}
+            self.options = {}
+    config_entries.ConfigEntry = ConfigEntry
+
+    core = types.ModuleType("homeassistant.core")
+    class HomeAssistant:
+        def __init__(self):
+            self.config_entries = types.SimpleNamespace(async_update_entry=lambda *args, **kwargs: None)
+    core.HomeAssistant = HomeAssistant
+
+    helpers = types.ModuleType("homeassistant.helpers")
+    entity = types.ModuleType("homeassistant.helpers.entity")
+    class DeviceInfo:
+        def __init__(self, **kwargs):
+            pass
+    entity.DeviceInfo = DeviceInfo
+    entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+    entity_platform.AddEntitiesCallback = object
+    helpers.entity = entity
+    helpers.entity_platform = entity_platform
+
+    monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
+    monkeypatch.setitem(sys.modules, "homeassistant.components", components)
+    monkeypatch.setitem(sys.modules, "homeassistant.components.button", button_module)
+    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries)
+    monkeypatch.setitem(sys.modules, "homeassistant.core", core)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity_platform", entity_platform)
+
+    from consumable_expiration.button import MarkReplacedButton, CONF_NAME
+
+    hass = core.HomeAssistant()
+    entry = config_entries.ConfigEntry()
+    entry.data = {CONF_NAME: "Test"}
+
+    button = MarkReplacedButton(hass, entry)
+
+    assert button.state == "idle"

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -3,8 +3,17 @@ import sys
 import types
 from pathlib import Path
 
+
 def test_button_default_state(monkeypatch):
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+    package = types.ModuleType("consumable_expiration")
+    package.__path__ = [
+        str(
+            Path(__file__).resolve().parents[1]
+            / "custom_components"
+            / "consumable_expiration"
+        )
+    ]
+    monkeypatch.setitem(sys.modules, "consumable_expiration", package)
 
     ha_module = types.ModuleType("homeassistant")
     components = types.ModuleType("homeassistant.components")
@@ -13,6 +22,10 @@ def test_button_default_state(monkeypatch):
     class ButtonEntity:
         def __init__(self):
             self._attr_state = None
+        @property
+        def state(self):
+            return self._attr_state
+
         def async_write_ha_state(self):
             pass
     button_module.ButtonEntity = ButtonEntity


### PR DESCRIPTION
## Summary
- ensure Mark Replaced button defaults to `idle` instead of `unknown`
- update button state when pressed
- add unit test for default state

## Testing
- `python3 -m py_compile custom_components/consumable_expiration/button.py tests/test_button.py`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a3ff571c832ea9daabcab4417092