### PR TITLE
chore: bump version to v0.1.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.15 - 2025-08-28
+- Bump version to 0.1.15
+
 ## 0.1.14 - 2025-08-28
 - Remove mandatory fields restriction in editing
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Home Assistant custom integration to track the life span of consumable items suc
    - `consumable_expiration.mark_replaced`
 
 ## Changelog
+- **0.1.15** – Bump version to 0.1.15.
 - **0.1.14** – Remove mandatory fields restriction in editing.
 - **0.1.13** – Allow reconfiguring consumables from the UI.
 - **0.1.12** – Bug fixes for Expiration Override.

--- a/custom_components/consumable_expiration/manifest.json
+++ b/custom_components/consumable_expiration/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "consumable_expiration",
   "name": "HA Expiring Consumables",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "documentation": "https://github.com/dfiore1230/HA-Expiring-Consumables",
   "dependencies": [],
   "requirements": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-expiring-consumables"
-version = "0.1.14"
+version = "0.1.15"
 description = "Home Assistant plugin to track consumables"
 readme = "README.md"
 authors = [{name = "dfiore1230"}]


### PR DESCRIPTION
## Summary
- bump project version to v0.1.15
- document release in README and changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1a51a34c4832eb4a9a9d7becc8987