### PR TITLE
Allow editing consumables without updating all fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 0.1.16 - 2025-08-29
-- Set default state of replace button to idle, set override expiry date to respect override start date + days
+- Allow editing consumables without re-entering unchanged fields
 
 ## 0.1.15 - 2025-08-29
 - Set default state of replace button to idle, set override expiry date to respect override start date + days

--- a/custom_components/consumable_expiration/config_flow.py
+++ b/custom_components/consumable_expiration/config_flow.py
@@ -142,12 +142,12 @@ class ConsumableOptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             name = (user_input.get(CONF_NAME) or data.get(CONF_NAME, "")).strip()
-            item_type = user_input.get(CONF_ITEM_TYPE, data.get(CONF_ITEM_TYPE))
-            icon = user_input.get(CONF_ICON, data.get(CONF_ICON))
+            item_type = user_input.get(CONF_ITEM_TYPE) or data.get(CONF_ITEM_TYPE)
+            icon = user_input.get(CONF_ICON) or data.get(CONF_ICON)
             duration = int(
-                user_input.get(CONF_DURATION_DAYS, options.get(CONF_DURATION_DAYS))
+                user_input.get(CONF_DURATION_DAYS) or options.get(CONF_DURATION_DAYS)
             )
-            start_date = user_input.get(CONF_START_DATE, options.get(CONF_START_DATE))
+            start_date = user_input.get(CONF_START_DATE) or options.get(CONF_START_DATE)
             expiry_override = user_input.get(CONF_EXPIRY_DATE_OVERRIDE)
 
             if isinstance(start_date, str):

--- a/custom_components/consumable_expiration/manifest.json
+++ b/custom_components/consumable_expiration/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "consumable_expiration",
   "name": "HA Expiring Consumables",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "documentation": "https://github.com/dfiore1230/HA-Expiring-Consumables",
   "dependencies": [],
   "requirements": [],

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -266,6 +266,32 @@ def test_config_flow_form_and_entry(monkeypatch):
     assert result_partial["data"][cf_module.CONF_START_DATE] == "2024-01-01"
     assert config_entry_partial.data[cf_module.CONF_NAME] == "Updated"
 
+    # None values should preserve existing fields
+    config_entry_none = cf_module.config_entries.ConfigEntry()
+    config_entry_none.data = {
+        cf_module.CONF_NAME: "Filter",
+        cf_module.CONF_ITEM_TYPE: "typeA",
+        cf_module.CONF_ICON: "mdi:filter",
+    }
+    config_entry_none.options = {
+        cf_module.CONF_DURATION_DAYS: 30,
+        cf_module.CONF_START_DATE: "2024-01-01",
+    }
+    options_flow_none = cf_module.ConsumableConfigFlow.async_get_options_flow(config_entry_none)
+    options_flow_none.hass = hass
+    asyncio.run(options_flow_none.async_step_init())
+    user_none = {
+        cf_module.CONF_NAME: "Updated",
+        cf_module.CONF_ITEM_TYPE: None,
+        cf_module.CONF_ICON: None,
+        cf_module.CONF_DURATION_DAYS: None,
+        cf_module.CONF_START_DATE: None,
+    }
+    result_none = asyncio.run(options_flow_none.async_step_init(user_input=user_none))
+    assert config_entry_none.data[cf_module.CONF_ITEM_TYPE] == "typeA"
+    assert config_entry_none.data[cf_module.CONF_ICON] == "mdi:filter"
+    assert result_none["data"][cf_module.CONF_START_DATE] == "2024-01-01"
+
     # Test reconfigure flow delegates to options flow
     config_entry2 = cf_module.config_entries.ConfigEntry()
     config_entry2.entry_id = "abc123"


### PR DESCRIPTION
## Summary
- Preserve existing values when optional fields are left blank during reconfiguration
- Note behavior in changelog and bump version
- Test handling of `None` values in options flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a888a640832ea38991506760b961