### PR TITLE
Handle button restore and safe config updates

### DIFF
--- a/custom_components/consumable_expiration/__init__.py
+++ b/custom_components/consumable_expiration/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_DURATION_DAYS,
     CONF_START_DATE,
 )
+from .util import merge_entry_options
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +108,7 @@ def _register_services(hass: HomeAssistant) -> None:
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
-        options = {**entry.options, CONF_START_DATE: new_date.isoformat()}
+        options = merge_entry_options(entry, **{CONF_START_DATE: new_date.isoformat()})
         hass.config_entries.async_update_entry(entry, options=options)
 
     async def handle_set_duration(call: ServiceCall):
@@ -116,7 +117,7 @@ def _register_services(hass: HomeAssistant) -> None:
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
-        options = {**entry.options, CONF_DURATION_DAYS: days}
+        options = merge_entry_options(entry, **{CONF_DURATION_DAYS: days})
         hass.config_entries.async_update_entry(entry, options=options)
 
     async def handle_mark_replaced(call: ServiceCall):
@@ -125,7 +126,7 @@ def _register_services(hass: HomeAssistant) -> None:
         if not entry:
             return
         today = dt.date.today().isoformat()
-        options = {**entry.options, CONF_START_DATE: today}
+        options = merge_entry_options(entry, **{CONF_START_DATE: today})
         hass.config_entries.async_update_entry(entry, options=options)
 
     hass.services.async_register(

--- a/custom_components/consumable_expiration/util.py
+++ b/custom_components/consumable_expiration/util.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Any, TYPE_CHECKING, Dict
+
+from .const import CONF_DURATION_DAYS, CONF_START_DATE
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+
+def merge_entry_options(entry: "ConfigEntry", **updates: Any) -> Dict[str, Any]:
+    """Return updated options preserving existing values.
+
+    Ensures that required option fields like duration and start date are
+    retained when only a subset of options are provided during an update.
+    """
+    options: Dict[str, Any] = dict(getattr(entry, "options", {}))
+    data = getattr(entry, "data", {})
+
+    if CONF_DURATION_DAYS not in options and CONF_DURATION_DAYS in data:
+        options[CONF_DURATION_DAYS] = data[CONF_DURATION_DAYS]
+    if CONF_START_DATE not in options and CONF_START_DATE in data:
+        options[CONF_START_DATE] = data[CONF_START_DATE]
+
+    options.update(updates)
+    return options

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,11 +1,10 @@
-
 import sys
 import types
 import asyncio
 from pathlib import Path
 
 
-def test_button_default_state(monkeypatch):
+def _setup_modules(monkeypatch, last_state=None):
     package = types.ModuleType("consumable_expiration")
     package.__path__ = [
         str(
@@ -15,6 +14,8 @@ def test_button_default_state(monkeypatch):
         )
     ]
     monkeypatch.setitem(sys.modules, "consumable_expiration", package)
+    sys.modules.pop("consumable_expiration.button", None)
+    sys.modules.pop("consumable_expiration.util", None)
 
     ha_module = types.ModuleType("homeassistant")
     components = types.ModuleType("homeassistant.components")
@@ -26,7 +27,6 @@ def test_button_default_state(monkeypatch):
         @property
         def state(self):
             return self._attr_state
-
         def async_write_ha_state(self):
             pass
         async def async_added_to_hass(self):
@@ -57,8 +57,14 @@ def test_button_default_state(monkeypatch):
     entity.DeviceInfo = DeviceInfo
     entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
     entity_platform.AddEntitiesCallback = object
+    restore_state = types.ModuleType("homeassistant.helpers.restore_state")
+    class RestoreEntity:
+        async def async_get_last_state(self):
+            return last_state
+    restore_state.RestoreEntity = RestoreEntity
     helpers.entity = entity
     helpers.entity_platform = entity_platform
+    helpers.restore_state = restore_state
 
     monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
     monkeypatch.setitem(sys.modules, "homeassistant.components", components)
@@ -68,7 +74,13 @@ def test_button_default_state(monkeypatch):
     monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity)
     monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity_platform", entity_platform)
+    monkeypatch.setitem(sys.modules, "homeassistant.helpers.restore_state", restore_state)
 
+    return core, config_entries
+
+
+def test_button_default_state(monkeypatch):
+    core, config_entries = _setup_modules(monkeypatch)
     from consumable_expiration.button import MarkReplacedButton, CONF_NAME
 
     hass = core.HomeAssistant()
@@ -76,75 +88,11 @@ def test_button_default_state(monkeypatch):
     entry.data = {CONF_NAME: "Test"}
 
     button = MarkReplacedButton(hass, entry)
-
     assert button.state == "idle"
 
 
 def test_button_resets_state_on_add(monkeypatch):
-    package = types.ModuleType("consumable_expiration")
-    package.__path__ = [
-        str(
-            Path(__file__).resolve().parents[1]
-            / "custom_components"
-            / "consumable_expiration"
-        )
-    ]
-    monkeypatch.setitem(sys.modules, "consumable_expiration", package)
-
-    ha_module = types.ModuleType("homeassistant")
-    components = types.ModuleType("homeassistant.components")
-    button_module = types.ModuleType("homeassistant.components.button")
-
-    class ButtonEntity:
-        def __init__(self):
-            self._attr_state = None
-        @property
-        def state(self):
-            return self._attr_state
-
-        def async_write_ha_state(self):
-            pass
-
-        async def async_added_to_hass(self):
-            pass
-    button_module.ButtonEntity = ButtonEntity
-    components.button = button_module
-    ha_module.components = components
-
-    config_entries = types.ModuleType("homeassistant.config_entries")
-    class ConfigEntry:
-        def __init__(self):
-            self.entry_id = "1"
-            self.data = {}
-            self.options = {}
-    config_entries.ConfigEntry = ConfigEntry
-
-    core = types.ModuleType("homeassistant.core")
-    class HomeAssistant:
-        def __init__(self):
-            self.config_entries = types.SimpleNamespace(async_update_entry=lambda *args, **kwargs: None)
-    core.HomeAssistant = HomeAssistant
-
-    helpers = types.ModuleType("homeassistant.helpers")
-    entity = types.ModuleType("homeassistant.helpers.entity")
-    class DeviceInfo:
-        def __init__(self, **kwargs):
-            pass
-    entity.DeviceInfo = DeviceInfo
-    entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
-    entity_platform.AddEntitiesCallback = object
-    helpers.entity = entity
-    helpers.entity_platform = entity_platform
-
-    monkeypatch.setitem(sys.modules, "homeassistant", ha_module)
-    monkeypatch.setitem(sys.modules, "homeassistant.components", components)
-    monkeypatch.setitem(sys.modules, "homeassistant.components.button", button_module)
-    monkeypatch.setitem(sys.modules, "homeassistant.config_entries", config_entries)
-    monkeypatch.setitem(sys.modules, "homeassistant.core", core)
-    monkeypatch.setitem(sys.modules, "homeassistant.helpers", helpers)
-    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity", entity)
-    monkeypatch.setitem(sys.modules, "homeassistant.helpers.entity_platform", entity_platform)
-
+    core, config_entries = _setup_modules(monkeypatch)
     from consumable_expiration.button import MarkReplacedButton, CONF_NAME
 
     hass = core.HomeAssistant()
@@ -157,3 +105,18 @@ def test_button_resets_state_on_add(monkeypatch):
     asyncio.run(button.async_added_to_hass())
 
     assert button.state == "idle"
+
+
+def test_button_restores_last_state(monkeypatch):
+    last = types.SimpleNamespace(state="2024-01-01T00:00:00")
+    core, config_entries = _setup_modules(monkeypatch, last_state=last)
+    from consumable_expiration.button import MarkReplacedButton, CONF_NAME
+
+    hass = core.HomeAssistant()
+    entry = config_entries.ConfigEntry()
+    entry.data = {CONF_NAME: "Test"}
+
+    button = MarkReplacedButton(hass, entry)
+    asyncio.run(button.async_added_to_hass())
+
+    assert button.state == "2024-01-01T00:00:00"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,35 @@
+import sys
+from pathlib import Path
+import types
+
+
+def test_merge_entry_options_preserves_fields(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+    from consumable_expiration.util import merge_entry_options
+    from consumable_expiration.const import CONF_DURATION_DAYS, CONF_START_DATE
+
+    class ConfigEntry:
+        def __init__(self):
+            self.data = {}
+            self.options = {CONF_DURATION_DAYS: 30, CONF_START_DATE: "2024-01-01"}
+
+    entry = ConfigEntry()
+    new_options = merge_entry_options(entry, **{CONF_START_DATE: "2024-02-01"})
+    assert new_options[CONF_DURATION_DAYS] == 30
+    assert new_options[CONF_START_DATE] == "2024-02-01"
+
+
+def test_merge_entry_options_uses_data(monkeypatch):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components"))
+    from consumable_expiration.util import merge_entry_options
+    from consumable_expiration.const import CONF_DURATION_DAYS, CONF_START_DATE
+
+    class ConfigEntry:
+        def __init__(self):
+            self.data = {CONF_DURATION_DAYS: 45, CONF_START_DATE: "2024-03-01"}
+            self.options = {}
+
+    entry = ConfigEntry()
+    new_options = merge_entry_options(entry, **{CONF_START_DATE: "2024-04-01"})
+    assert new_options[CONF_DURATION_DAYS] == 45
+    assert new_options[CONF_START_DATE] == "2024-04-01"


### PR DESCRIPTION
## Summary
- make MarkReplacedButton restore its last state on startup
- ensure service and button option updates merge existing fields
- add tests for button restoration and option merging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c6322bc0832ebf00669245d2cd06