### PR TITLE
Reset mark replaced button to idle on startup

### DIFF
--- a/custom_components/consumable_expiration/button.py
+++ b/custom_components/consumable_expiration/button.py
@@ -8,7 +8,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN, CONF_NAME, CONF_START_DATE
 from .util import merge_entry_options
@@ -18,7 +17,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     async_add_entities([MarkReplacedButton(hass, entry)])
 
 
-class MarkReplacedButton(ButtonEntity, RestoreEntity):
+class MarkReplacedButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "mark_replaced"
     _attr_state = "idle"
@@ -43,13 +42,9 @@ class MarkReplacedButton(ButtonEntity, RestoreEntity):
         return "mdi:backup-restore"
 
     async def async_added_to_hass(self) -> None:
-        """Restore the previous state or reset to idle on startup."""
+        """Ensure the button starts in the idle state on startup."""
         await super().async_added_to_hass()
-        last_state = await self.async_get_last_state()
-        if last_state and last_state.state not in (None, "unknown"):
-            self._attr_state = last_state.state
-        else:
-            self._attr_state = "idle"
+        self._attr_state = "idle"
         self.async_write_ha_state()
 
     async def async_press(self) -> None:

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -107,7 +107,7 @@ def test_button_resets_state_on_add(monkeypatch):
     assert button.state == "idle"
 
 
-def test_button_restores_last_state(monkeypatch):
+def test_button_does_not_restore_last_state(monkeypatch):
     last = types.SimpleNamespace(state="2024-01-01T00:00:00")
     core, config_entries = _setup_modules(monkeypatch, last_state=last)
     from consumable_expiration.button import MarkReplacedButton, CONF_NAME
@@ -119,4 +119,4 @@ def test_button_restores_last_state(monkeypatch):
     button = MarkReplacedButton(hass, entry)
     asyncio.run(button.async_added_to_hass())
 
-    assert button.state == "2024-01-01T00:00:00"
+    assert button.state == "idle"


### PR DESCRIPTION
## Summary
- ensure Mark Replaced button resets to `idle` on startup
- update tests to reflect non-restored state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e326c7ec832eae66f961394daa11