### PR TITLE
Add debug logging to track consumable updates

### DIFF
--- a/custom_components/consumable_expiration/__init__.py
+++ b/custom_components/consumable_expiration/__init__.py
@@ -76,15 +76,21 @@ def _register_services(hass: HomeAssistant) -> None:
     import homeassistant.helpers.config_validation as cv
 
     async def _resolve_entry_from_entity(hass: HomeAssistant, entity_id: str):
+        _LOGGER.debug("Resolving config entry for entity %s", entity_id)
         emap: dict[str, str] = hass.data[DOMAIN]["entity_map"]
         entry_id = emap.get(entity_id)
+        if entry_id:
+            _LOGGER.debug("Found entry %s in entity map for %s", entry_id, entity_id)
         if not entry_id:
             # Fallback: look up via entity registry to get config entry id
+            _LOGGER.debug("Entity %s not found in map; checking entity registry", entity_id)
             ent_reg = er.async_get(hass)
             ent = ent_reg.async_get(entity_id)
             if ent:
                 entry_id = ent.config_entry_id
+                _LOGGER.debug("Resolved entry %s via entity registry for %s", entry_id, entity_id)
         if not entry_id:
+            _LOGGER.debug("Could not resolve config entry for %s", entity_id)
             raise vol.Invalid(f"Could not resolve config entry for {entity_id}")
         return hass.config_entries.async_get_entry(entry_id)
 
@@ -111,41 +117,52 @@ def _register_services(hass: HomeAssistant) -> None:
     async def handle_set_start(call: ServiceCall):
         entity_id = call.data["entity_id"]
         new_date: dt.date = call.data["start_date"]
+        _LOGGER.debug("Service set_start_date called for %s with %s", entity_id, new_date)
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
         options = merge_entry_options(entry, **{CONF_START_DATE: new_date.isoformat()})
+        _LOGGER.debug("Updating entry %s options to %s", entry.entry_id, options)
         hass.config_entries.async_update_entry(entry, options=options)
 
     async def handle_set_expiry(call: ServiceCall):
         entity_id = call.data["entity_id"]
         new_expiry: dt.date = call.data["expiry_date"]
+        _LOGGER.debug("Service set_expiry_date called for %s with %s", entity_id, new_expiry)
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
         duration = entry.options.get(CONF_DURATION_DAYS) or entry.data.get(CONF_DURATION_DAYS)
         if not duration:
+            _LOGGER.debug("Duration missing for %s", entity_id)
             raise vol.Invalid("Duration not configured")
         start_date = new_expiry - dt.timedelta(days=duration)
         options = merge_entry_options(entry, **{CONF_START_DATE: start_date.isoformat()})
+        _LOGGER.debug(
+            "Updating entry %s options to %s for expiry", entry.entry_id, options
+        )
         hass.config_entries.async_update_entry(entry, options=options)
 
     async def handle_set_duration(call: ServiceCall):
         entity_id = call.data["entity_id"]
         days: int = call.data["duration_days"]
+        _LOGGER.debug("Service set_duration called for %s with %s", entity_id, days)
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
         options = merge_entry_options(entry, **{CONF_DURATION_DAYS: days})
+        _LOGGER.debug("Updating entry %s options to %s", entry.entry_id, options)
         hass.config_entries.async_update_entry(entry, options=options)
 
     async def handle_mark_replaced(call: ServiceCall):
         entity_id = call.data["entity_id"]
+        _LOGGER.debug("Service mark_replaced called for %s", entity_id)
         entry = await _resolve_entry_from_entity(hass, entity_id)
         if not entry:
             return
         today = dt.date.today().isoformat()
         options = merge_entry_options(entry, **{CONF_START_DATE: today})
+        _LOGGER.debug("Updating entry %s options to %s", entry.entry_id, options)
         hass.config_entries.async_update_entry(entry, options=options)
 
     hass.services.async_register(

--- a/custom_components/consumable_expiration/button.py
+++ b/custom_components/consumable_expiration/button.py
@@ -9,8 +9,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+import logging
+
 from .const import DOMAIN, CONF_NAME, CONF_START_DATE
 from .util import merge_entry_options
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -45,11 +49,17 @@ class MarkReplacedButton(ButtonEntity):
         """Ensure the button starts in the idle state on startup."""
         await super().async_added_to_hass()
         self._attr_state = "idle"
+        _LOGGER.debug("MarkReplacedButton added for entry %s", self.entry.entry_id)
         self.async_write_ha_state()
 
     async def async_press(self) -> None:
         today = dt.date.today().isoformat()
         options = merge_entry_options(self.entry, **{CONF_START_DATE: today})
+        _LOGGER.debug(
+            "MarkReplacedButton pressed for entry %s; updating start_date to %s",
+            self.entry.entry_id,
+            today,
+        )
         self.hass.config_entries.async_update_entry(self.entry, options=options)
         self._attr_state = dt.datetime.now().isoformat()
         self.async_write_ha_state()

--- a/custom_components/consumable_expiration/sensor.py
+++ b/custom_components/consumable_expiration/sensor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime as dt
 from typing import Any
+import logging
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.sensor.const import SensorStateClass
@@ -20,6 +21,8 @@ from .const import (
     CONF_START_DATE,
     CONF_ICON,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
 
@@ -112,6 +115,7 @@ class ConsumableExpirationSensor(SensorEntity):
                 y, m, d = map(int, start.split("-"))
                 start_date = dt.date(y, m, d)
             except Exception:
+                _LOGGER.debug("Failed to parse start_date '%s' for %s", start, self.entry.entry_id)
                 start_date = None
         elif isinstance(start, dt.date):
             start_date = start
@@ -120,5 +124,12 @@ class ConsumableExpirationSensor(SensorEntity):
         try:
             duration = int(duration) if duration is not None else None
         except Exception:
+            _LOGGER.debug("Invalid duration '%s' for %s", duration, self.entry.entry_id)
             duration = None
+        _LOGGER.debug(
+            "Parsed params for %s: duration=%s, start_date=%s",
+            self.entry.entry_id,
+            duration,
+            start_date,
+        )
         return duration, start_date


### PR DESCRIPTION
## Summary
- add detailed debug logging when resolving entities and running services
- log Mark Replaced button interactions
- trace sensor parameter parsing for easier troubleshooting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2132fc75c832eb51c92817717b209