### PR TITLE
Prepare 0.1.22 release metadata and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.22 - 2026-02-18
+- Added the ability to modify the entity duration
+- Added logging
+
 ## 0.1.21 - 2025-08-29
 - Added update_expiry service, set idle staticlly on restart
 

--- a/custom_components/consumable_expiration/manifest.json
+++ b/custom_components/consumable_expiration/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "consumable_expiration",
   "name": "HA Expiring Consumables",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "documentation": "https://github.com/dfiore1230/HA-Expiring-Consumables",
   "dependencies": [],
   "requirements": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-expiring-consumables"
-version = "0.1.21"
+version = "0.1.22"
 description = "Home Assistant plugin to track consumables"
 readme = "README.md"
 authors = [{name = "dfiore1230"}]


### PR DESCRIPTION
### Motivation
- Prepare repository metadata for a new `0.1.22` release so package artifacts, integration runtime metadata, and changelog are consistent.

### Description
- Bump package `version` to `0.1.22` in `pyproject.toml`.
- Update Home Assistant integration `version` to `0.1.22` in `custom_components/consumable_expiration/manifest.json`.
- Add a `0.1.22` entry to `CHANGELOG.md` documenting the ability to modify entity duration and added logging.
- Align release metadata so tagging `v0.1.22` in CI will produce correctly versioned artifacts.

### Testing
- Ran `pytest` and all tests passed (`8 passed`).
- Built a wheel with `python -m pip wheel --no-build-isolation . -w dist`, which succeeded.
- Attempted `python -m build` but it failed because the `build` module could not be installed in this environment due to network/proxy restrictions (403).
- Attempted `pip install build` and it failed for the same proxy/network restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995c8e90c3c832e81690a50713de222)