### PR TITLE
Improve build workflow to reliably publish release artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,9 @@ name: Build Package
 on:
   push:
     branches: [main]
-    tags: ['*']
+    tags: ['v*']
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -14,16 +16,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install build tooling
-        run: pip install build
+        run: python -m pip install --upgrade pip build
       - name: Build package
         run: python -m build
-      - name: Create release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/*
+          if-no-files-found: error
+      - name: Publish release assets
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
         with:
           files: dist/*
+          fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.22 - 2026-02-18
+- Added the ability to modify the entity duration
+- Added logging
+
 ## 0.1.21 - 2025-08-29
 - Added update_expiry service, set idle staticlly on restart
 

--- a/custom_components/consumable_expiration/manifest.json
+++ b/custom_components/consumable_expiration/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "consumable_expiration",
   "name": "HA Expiring Consumables",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "documentation": "https://github.com/dfiore1230/HA-Expiring-Consumables",
   "dependencies": [],
   "requirements": [],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ha-expiring-consumables"
-version = "0.1.21"
+version = "0.1.22"
 description = "Home Assistant plugin to track consumables"
 readme = "README.md"
 authors = [{name = "dfiore1230"}]


### PR DESCRIPTION
### Motivation
- Ensure Python distribution artifacts are always produced and available after merges or releases so a missing release package does not block consumers. 
- Make release asset publishing deterministic for tag and published release events. 
- Bump package/integration version and changelog for the `0.1.22` release.

### Description
- Updated `.github/workflows/build.yml` to trigger on `push` to `main`, `v*` tag pushes, and `release` published events, upgraded actions to `checkout@v4` and `setup-python@v5`, and install build tooling with `python -m pip install --upgrade pip build`. 
- Added `python -m build` step, `actions/upload-artifact@v4` to store `dist/*` as an Actions artifact (`python-dist`), and retained release publishing using `softprops/action-gh-release@v2` with `fail_on_unmatched_files: true`. 
- Bumped integration version in `custom_components/consumable_expiration/manifest.json` and package `version` in `pyproject.toml` to `0.1.22` and added a `0.1.22` entry to `CHANGELOG.md` documenting the changes. 

### Testing
- Ran `pytest -q` and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995c8e90c3c832e81690a50713de222)